### PR TITLE
for Django3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -42,46 +40,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=1.5.0,<1.6.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=1.6.0,<1.7.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=1.7.0,<1.8.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=2.0.0,<2.1.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=2.1.0,<2.2.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=2.2.0,<2.3.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=3.0.0,<3.1.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=3.1.0,<3.2.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=3.2.0,<3.3.0' DB='all'
-    - python: 3.2
-      env: SQLOBJECT='sqlobject>=3.3.0,<3.4.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=1.5.0,<1.6.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=1.6.0,<1.7.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=1.7.0,<1.8.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=2.0.0,<2.1.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=2.1.0,<2.2.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=2.2.0,<2.3.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=3.0.0,<3.1.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=3.1.0,<3.2.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=3.2.0,<3.3.0' DB='all'
-    - python: 3.3
-      env: SQLOBJECT='sqlobject>=3.3.0,<3.4.0' DB='all'
     - python: 3.4
       env: SQLOBJECT='sqlobject>=1.5.0,<1.6.0' DB='all'
     - python: 3.4
@@ -118,22 +76,6 @@ matrix:
       env: SQLOBJECT='sqlobject>=2.1.0,<2.2.0' DB='all'
     - python: 3.6
       env: SQLOBJECT='sqlobject>=2.2.0,<2.3.0' DB='all'
-    - python: 3.2
-      env: DJANGO='django>=1.4.0,<1.5.0' DB='all'
-    - python: 3.2
-      env: DJANGO='django>=1.9.0,<1.10.0' DB='all'
-    - python: 3.2
-      env: DJANGO='django>=1.10.0,<1.11.0' DB='all'
-    - python: 3.2
-      env: DJANGO='django>=1.11.0,<1.12.0' DB='all'
-    - python: 3.3
-      env: DJANGO='django>=1.4.0,<1.5.0' DB='all'
-    - python: 3.3
-      env: DJANGO='django>=1.9.0,<1.10.0' DB='all'
-    - python: 3.3
-      env: DJANGO='django>=1.10.0,<1.11.0' DB='all'
-    - python: 3.3
-      env: DJANGO='django>=1.11.0,<1.12.0' DB='all'
     - python: 3.4
       env: DJANGO='django>=1.4.0,<1.5.0' DB='all'
     - python: 3.5
@@ -152,14 +94,6 @@ matrix:
       env: DJANGO='django>=1.6.0,<1.7.0' DB='all'
     - python: 3.6
       env: DJANGO='django>=1.7.0,<1.8.0' DB='all'
-    - python: 3.2
-      env: PONY='pony>=0.5.0,<0.6.0' DB='all'
-    - python: 3.2
-      env: PONY='pony>=0.6.0,<0.7.0' DB='all'
-    - python: 3.2
-      env: PONY='pony>=0.7.0,<0.8.0' DB='all'
-    - python: 3.3
-      env: PONY='pony>=0.5.0,<0.6.0' DB='all'
     - python: 3.4
       env: PONY='pony>=0.5.0,<0.6.0' DB='all'
     - python: 3.5
@@ -168,14 +102,6 @@ matrix:
       env: PONY='pony>=0.5.0,<0.6.0' DB='all'
     - python: 3.6
       env: PONY='pony>=0.6.0,<0.7.0' DB='all'
-    - python: 3.2
-      env: PEEWEE='peewee>=2.8.0,<2.9.0' DB='all'
-    - python: 3.2
-      env: PEEWEE='peewee>=2.9.0,<2.10.0' DB='all'
-    - python: 3.3
-      env: PEEWEE='peewee>=2.8.0,<2.9.0' DB='all'
-    - python: 3.3
-      env: PEEWEE='peewee>=2.9.0,<2.10.0' DB='all'
 before_script:
   - psql -c 'create database architect;' -U postgres
   - mysql -e 'create database architect;' -u root
@@ -185,7 +111,6 @@ services:
 install:
   - travis_retry pip install -r tests/requirements.txt
   - travis_retry pip install coveralls psycopg2 pymysql
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install 'coverage<4.0' 'pymysql<0.7.0'; fi
   - if [[ $DJANGO ]]; then travis_retry pip install $DJANGO; fi
   - if [[ $PEEWEE ]]; then travis_retry pip install $PEEWEE; fi
   - if [[ $PONY ]]; then travis_retry pip install $PONY; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -179,6 +179,9 @@ matrix:
 before_script:
   - psql -c 'create database architect;' -U postgres
   - mysql -e 'create database architect;' -u root
+services:
+  - postgresql
+  - mysql
 install:
   - travis_retry pip install -r tests/requirements.txt
   - travis_retry pip install coveralls psycopg2 pymysql

--- a/architect/orms/django/features.py
+++ b/architect/orms/django/features.py
@@ -2,14 +2,19 @@
 Defines features for the Django ORM.
 """
 
+import django
 from django.conf import settings
 from django.db import router, connections, transaction
-from django.db.models.fields import FieldDoesNotExist
 from django.db.utils import ConnectionDoesNotExist
 from django.utils.functional import cached_property
 
 from ..bases import BasePartitionFeature, BaseOperationFeature
 from ...exceptions import PartitionColumnError, OptionNotSetError, OptionValueError
+
+if django.VERSION < (1, 8):
+    from django.db.models.fields import FieldDoesNotExist
+else:
+    from django.core.exceptions import FieldDoesNotExist
 
 
 class ConnectionMixin(object):

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,6 @@ setup(
         'Programming Language :: SQL',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -8,7 +8,7 @@ To run tests you will need these packages:
 * mock
 
 For your convenience they are all listed in the ``requirements.txt`` file in this directory.
-If you are running Python 3.3+ ``mock`` already exists in the standard library as a part of
+If you are running Python 3.4+ ``mock`` already exists in the standard library as a part of
 unittest package so you don't need to install it. For Python 2.6 you also need to install
 ``unittest2`` package. After all dependencies are installed you can run tests with this command:
 


### PR DESCRIPTION
- FieldDoesNotExist is removed from django.db.models.fields in django3.1.
- psql: could not connect to server error on “travis-ci” (https://stackoverflow.com/questions/49850020/psql-could-not-connect-to-server-error-on-travis-ci)
- Not to support python 3.2 and 3.3 because these versions haven't already hosted on GCP